### PR TITLE
Removing lines to allow docker hub to build correctly

### DIFF
--- a/build-files/Dockerfile
+++ b/build-files/Dockerfile
@@ -5,9 +5,6 @@ RUN apk update
 RUN apk upgrade --repository http://dl-4.alpinelinux.org/alpine/edge/community \
                 --repository https://nl.alpinelinux.org/alpine/edge/main
 
-    # Make info file about this build
-    printf "Build of skipper/alpine-apache, date: %s\n"  `date -u +"%Y-%m-%dT%H:%M:%SZ"` >> /etc/BUILD
-
 RUN apk add --no-cache \
             jq \
             php7-session@community \


### PR DESCRIPTION
Docker hub is not building correctly. This printf is throwing an error. I just took it out. It is unnecessary, as I had copied info from another Dockerfile and
just changed the names.